### PR TITLE
Add property for disabling lum-sat square rotation

### DIFF
--- a/include/color_wheel.hpp
+++ b/include/color_wheel.hpp
@@ -42,6 +42,7 @@ class QCP_EXPORT Color_Wheel : public QWidget
     Q_PROPERTY(qreal saturation READ saturation WRITE setSaturation DESIGNABLE false )
     Q_PROPERTY(qreal value READ value WRITE setValue DESIGNABLE false )
     Q_PROPERTY(unsigned wheelWidth READ wheelWidth WRITE setWheelWidth DESIGNABLE true )
+    Q_PROPERTY(bool rotatingSquare READ rotatingSquare WRITE setRotatingSquare DESIGNABLE true )
 
 public:
     explicit Color_Wheel(QWidget *parent = 0);
@@ -67,6 +68,12 @@ public:
     /// Set the width in pixels of the outer wheel
     void setWheelWidth(unsigned int w);
 
+    /// Does the color square rotate with hue selection
+    bool rotatingSquare() const;
+
+    /// Set the default value for rotatingSquare for new Color_Wheel objects
+    static void setDefaultRotatingSquare(bool rotate);
+
 public slots:
 
     /// Set current color
@@ -86,6 +93,9 @@ public slots:
      * @param v Value [0-1]
     */
     void setValue(qreal v);
+
+    //! Enable/disable color square rotation
+    void setRotatingSquare(bool rotate);
 
 signals:
     /**


### PR DESCRIPTION
I received this feature request for my program that uses Qt-Color-Picker. Picking shades with the non-rotating color wheel is easier, and this style is fairly commonly used, including by programs such as Krita, Photoshop and Sai.
